### PR TITLE
Added markdown linter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 node_modules
-dist/
+dist
+
+# Files for testing the script locally
+test
+MLproject

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,12 @@
         "@stoplight/spectral-core": "^1.12.2",
         "@stoplight/spectral-functions": "^1.6.1",
         "@stoplight/spectral-parsers": "^1.0.1",
-        "js-yaml": "^4.1.0"
+        "js-yaml": "^4.1.0",
+        "markdownlint": "^0.25.1"
       },
       "devDependencies": {
         "@types/js-yaml": "^4.0.5",
         "@types/node": "^17.0.38",
-        "@vercel/ncc": "^0.34.0",
         "typescript": "^4.7.2"
       }
     },
@@ -411,15 +411,6 @@
       "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.19.tgz",
       "integrity": "sha512-FDJNkyhmKLw7uEvTxx5tSXfPeQpO0iy73Ry+PmYZJvQy0QIWX8a7kJ4kLWRf+EbTPJEPDSgPXHaM7pzr5lmvCg=="
     },
-    "node_modules/@vercel/ncc": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.34.0.tgz",
-      "integrity": "sha512-G9h5ZLBJ/V57Ou9vz5hI8pda/YQX5HQszCs3AmIus3XzsmRn/0Ptic5otD3xVST8QLKk7AMk7AqpsyQGN7MZ9A==",
-      "dev": true,
-      "bin": {
-        "ncc": "dist/ncc/cli.js"
-      }
-    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -528,6 +519,14 @@
         "node": ">= 0.6.0"
       }
     },
+    "node_modules/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -608,6 +607,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/linkify-it": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+      "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+      "dependencies": {
+        "uc.micro": "^1.0.1"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -627,6 +634,37 @@
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/lodash.topath/-/lodash.topath-4.5.2.tgz",
       "integrity": "sha512-1/W4dM+35DwvE/iEd1M9ekewOSTlpFekhw9mhAtrwjVqUr83/ilQiyAvmg4tVX7Unkcfl1KC+i9WdaT4B6aQcg=="
+    },
+    "node_modules/markdown-it": {
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "~2.1.0",
+        "linkify-it": "^3.0.1",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.js"
+      }
+    },
+    "node_modules/markdownlint": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.25.1.tgz",
+      "integrity": "sha512-AG7UkLzNa1fxiOv5B+owPsPhtM4D6DoODhsJgiaNg1xowXovrYgOnLqAgOOFQpWOlHFVQUzjMY5ypNNTeov92g==",
+      "dependencies": {
+        "markdown-it": "12.3.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g=="
     },
     "node_modules/minimatch": {
       "version": "3.0.4",
@@ -746,6 +784,11 @@
       "engines": {
         "node": ">=4.2.0"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -1111,12 +1154,6 @@
       "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.19.tgz",
       "integrity": "sha512-FDJNkyhmKLw7uEvTxx5tSXfPeQpO0iy73Ry+PmYZJvQy0QIWX8a7kJ4kLWRf+EbTPJEPDSgPXHaM7pzr5lmvCg=="
     },
-    "@vercel/ncc": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.34.0.tgz",
-      "integrity": "sha512-G9h5ZLBJ/V57Ou9vz5hI8pda/YQX5HQszCs3AmIus3XzsmRn/0Ptic5otD3xVST8QLKk7AMk7AqpsyQGN7MZ9A==",
-      "dev": true
-    },
     "abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -1195,6 +1232,11 @@
       "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.11.0.tgz",
       "integrity": "sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg=="
     },
+    "entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w=="
+    },
     "event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -1253,6 +1295,14 @@
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
       "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="
     },
+    "linkify-it": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+      "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+      "requires": {
+        "uc.micro": "^1.0.1"
+      }
+    },
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -1272,6 +1322,31 @@
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/lodash.topath/-/lodash.topath-4.5.2.tgz",
       "integrity": "sha512-1/W4dM+35DwvE/iEd1M9ekewOSTlpFekhw9mhAtrwjVqUr83/ilQiyAvmg4tVX7Unkcfl1KC+i9WdaT4B6aQcg=="
+    },
+    "markdown-it": {
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
+      "requires": {
+        "argparse": "^2.0.1",
+        "entities": "~2.1.0",
+        "linkify-it": "^3.0.1",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      }
+    },
+    "markdownlint": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.25.1.tgz",
+      "integrity": "sha512-AG7UkLzNa1fxiOv5B+owPsPhtM4D6DoODhsJgiaNg1xowXovrYgOnLqAgOOFQpWOlHFVQUzjMY5ypNNTeov92g==",
+      "requires": {
+        "markdown-it": "12.3.2"
+      }
+    },
+    "mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -1350,6 +1425,11 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.2.tgz",
       "integrity": "sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==",
       "dev": true
+    },
+    "uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
     },
     "uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "start": "node dist/index.js",
     "build": "tsc",
     "dev": "tsc -w",
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -28,6 +29,7 @@
     "@stoplight/spectral-core": "^1.12.2",
     "@stoplight/spectral-functions": "^1.6.1",
     "@stoplight/spectral-parsers": "^1.0.1",
-    "js-yaml": "^4.1.0"
+    "js-yaml": "^4.1.0",
+    "markdownlint": "^0.25.1"
   }
 }

--- a/src/functions/markdownValidator.ts
+++ b/src/functions/markdownValidator.ts
@@ -1,0 +1,24 @@
+import markdownlint from 'markdownlint'
+
+export default (input: string) => {
+  const options = {
+    'strings': {
+      'input': input,
+    },
+  };
+  
+  let resString: string = ''
+  markdownlint(options, (err, res) => {
+    if (!err && res && res.toString()) {
+      resString = res.toString();
+    } else if (err) {
+      console.log('ERROR',err)
+    }
+  })
+
+  return [
+    {
+      message: resString,
+    },
+  ];
+};

--- a/src/validator/rules.ts
+++ b/src/validator/rules.ts
@@ -1,15 +1,23 @@
 import { truthy } from '@stoplight/spectral-functions';
+import markdownValidator from '../functions/markdownValidator';
 
 const rules = {
   // TODO: The rules should be fixed. (This a dummy set)
   rules: {
     'no-empty-description': {
-      given: '$.description',
+      given: '$..description',
       message: 'Description must not be empty',
       then: {
         function: truthy,
       },
     },
+    'valid-markdown': {
+      given: '$..description',
+      message: '{{error}}',
+      then: {
+        function: markdownValidator,
+      },
+    }
   },
 };
 


### PR DESCRIPTION
Uses the [markdownlint](https://github.com/DavidAnson/markdownlint) library to check for style errors in any 'description' -properties. Currently only logs the found issues but does not do anything further. Also it only uses the default configuration options, but custom rules can be added later on.

Resolves #12 