### PR TITLE
Updated error message to include colored error severity

### DIFF
--- a/src/helpers/check.test.ts
+++ b/src/helpers/check.test.ts
@@ -1,34 +1,34 @@
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import { makeOutput, renderModelCard } from './check';
+import { validator } from '../validator';
 
 describe('Checks', () => {
   describe('makeOutput', () => {
-    it.skip('renders validation problems', () => {});
+    describe('Valid model card', () => {
+      it('renders model card output', () => {
+        const res = makeOutput(
+          [],
+          readFileSync(
+            join(__dirname, '../validator/__fixtures__/basic.yaml'),
+            'utf8',
+          ),
+        );
 
-    it('renders model card output', () => {
-      const res = makeOutput(
-        [],
-        readFileSync(
-          join(__dirname, '../validator/__fixtures__/basic.yaml'),
-          'utf8',
-        ),
-      );
-
-      expect(res.title).toEqual('Model cards');
+        expect(res.title).toEqual('Model cards');
+      });
     });
-  });
 
-  describe('renderModelCard', () => {
-    it('renders model card', () => {
-      const res = renderModelCard(
-        readFileSync(
-          join(__dirname, '../validator/__fixtures__/basic.yaml'),
-          'utf8',
-        ),
-      );
+    describe('renderModelCard', () => {
+      it('renders model card', () => {
+        const res = renderModelCard(
+          readFileSync(
+            join(__dirname, '../validator/__fixtures__/basic.yaml'),
+            'utf8',
+          ),
+        );
 
-      expect(res).toBe(`## Model card
+        expect(res).toBe(`## Model card
 
 Name: Facial Detection 
 Version: v0.0.0
@@ -47,6 +47,23 @@ The model analyzed in this card detects one or more faces within an image or a v
 * training
 
 * testing`);
+      });
+    });
+
+    describe('Invalid model card', () => {
+      it('renders validation problems, when MC has invalid schema', async () => {
+        const content = readFileSync(
+          join(__dirname, '../validator/__fixtures__/invalid_schema.yaml'),
+          'utf-8',
+        );
+
+        const errors = await validator(content);
+        const res = makeOutput(errors, '');
+
+        expect(res.summary).toBe(
+          '- **WARNING** at `quantitative_analysis.performance_metrics`: "performance_metrics" property type must be array',
+        );
+      });
     });
   });
 });

--- a/src/helpers/check.test.ts
+++ b/src/helpers/check.test.ts
@@ -61,7 +61,7 @@ The model analyzed in this card detects one or more faces within an image or a v
         const res = makeOutput(errors, '');
 
         expect(res.summary).toBe(
-          '- **WARNING** at `quantitative_analysis.performance_metrics`: "performance_metrics" property type must be array',
+          '- :warning: `quantitative_analysis.performance_metrics`: "performance_metrics" property type must be array',
         );
       });
     });

--- a/src/helpers/check.ts
+++ b/src/helpers/check.ts
@@ -4,11 +4,35 @@ import nunjucks from 'nunjucks';
 import { load } from 'js-yaml';
 import { join } from 'path';
 
+const severity = {
+  0: {
+    name: 'ERROR',
+    color: 'red',
+  },
+  1: {
+    name: 'WARNING',
+    color: 'yellow',
+  },
+  2: {
+    name: 'INFO',
+    color: 'blue',
+  },
+  3: {
+    name: 'HINT',
+    color: 'green',
+  },
+};
+
 const makeDiagnosticsSummary = (diagnostics: ISpectralDiagnostic[]) =>
   diagnostics
+    .sort((a, b) => a.severity - b.severity)
     .map((problem) => {
-      console.log(problem);
-      return `- \`${problem.path.join('.')}\``;
+      console.log('PROBLEM:', problem);
+      const str = `- **${
+        severity[problem.severity].name
+      }** at \`${problem.path.join('.')}\`: ${problem.message}`;
+      console.log(`Formatted string: ${str}`);
+      return str;
     })
     .join('\n');
 

--- a/src/helpers/check.ts
+++ b/src/helpers/check.ts
@@ -8,18 +8,22 @@ const severity = {
   0: {
     name: 'ERROR',
     color: 'red',
+    emojiString: ':x:',
   },
   1: {
     name: 'WARNING',
     color: 'yellow',
+    emojiString: ':warning:',
   },
   2: {
     name: 'INFO',
     color: 'blue',
+    emojiString: ':information_source:',
   },
   3: {
     name: 'HINT',
     color: 'green',
+    emojiString: ':point_up:',
   },
 };
 
@@ -28,9 +32,9 @@ const makeDiagnosticsSummary = (diagnostics: ISpectralDiagnostic[]) =>
     .sort((a, b) => a.severity - b.severity)
     .map((problem) => {
       console.log('PROBLEM:', problem);
-      const str = `- **${
-        severity[problem.severity].name
-      }** at \`${problem.path.join('.')}\`: ${problem.message}`;
+      const str = `- **${severity[problem.severity].name}** ${
+        severity[problem.severity].emojiString
+      } at \`${problem.path.join('.')}\`: ${problem.message}`;
       console.log(`Formatted string: ${str}`);
       return str;
     })

--- a/src/helpers/check.ts
+++ b/src/helpers/check.ts
@@ -23,7 +23,7 @@ const severity = {
   3: {
     name: 'HINT',
     color: 'green',
-    emojiString: ':point_up:',
+    emojiString: ':bulb:',
   },
 };
 
@@ -31,12 +31,9 @@ const makeDiagnosticsSummary = (diagnostics: ISpectralDiagnostic[]) =>
   diagnostics
     .sort((a, b) => a.severity - b.severity)
     .map((problem) => {
-      console.log('PROBLEM:', problem);
-      const str = `- **${severity[problem.severity].name}** ${
-        severity[problem.severity].emojiString
-      } at \`${problem.path.join('.')}\`: ${problem.message}`;
-      console.log(`Formatted string: ${str}`);
-      return str;
+      return `- ${severity[problem.severity].emojiString} \`${problem.path.join(
+        '.',
+      )}\`: ${problem.message}`;
     })
     .join('\n');
 

--- a/src/helpers/rule-loader.test.ts
+++ b/src/helpers/rule-loader.test.ts
@@ -1,6 +1,6 @@
 import loadCustomRuleset from './rule-loader';
 import { RulesetDefinition } from '@stoplight/spectral-core';
-// /Users/hgmarkus/uh-work/modelcard-action/
+
 describe('Custom rules', () => {
   describe('Rule loader', () => {
     it('loads custom rules', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ const main = async () => {
 
   // Find problems
   const diagnostics = await validator(raw, custom_rules);
+  diagnostics.length > 0 && console.log(makeOutput(diagnostics, ''));
 
   const token = process.env.TOKEN;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import * as core from '@actions/core';
 import { RulesetDefinition } from '@stoplight/spectral-core';
 import { validator } from './validator';
 import 'dotenv/config';
-import { makeCheckRun } from './helpers/check';
+import { makeCheckRun, makeOutput } from './helpers/check';
 import loadCustomRuleset from './helpers/rule-loader';
 import path from 'path';
 

--- a/src/validator/__fixtures__/invalid_schema.yaml
+++ b/src/validator/__fixtures__/invalid_schema.yaml
@@ -1,0 +1,36 @@
+model_details:
+  name: 'Facial Detection'
+  version:
+    name: 0.0.1
+    date: 2022-06-01
+  description: |
+    <!-- markdown description of model -->
+    ## Face Detection
+    The model analyzed in this card detects one or more faces within an image or a video frame, and returns a box around each face along with the location of the faces' major landmarks. The model's goal is exclusively to identify the existence and location of faces in an image. It does not attempt to discover identities or demographics.
+model_parameters:
+  data:
+    - name: training
+      description: A descriptive description
+    - name: testing
+      description: No further description provided
+quantitative_analysis:
+  data:
+    - name: FACES
+      description: FACES (A subset of Open Images) is a face detection evaluation dataset sampled from Open Images Dataset V4 by Google researchers.
+      link: https://storage.googleapis.com/openimages/web/index.html
+      size: 94866
+    - name: FDDB
+      description: Face Detection Data Set and Benchmark FDDB is a public dataset for face detection created by researchers at the University of Massachusetts, Amherst.
+      link: http://vis-www.cs.umass.edu/fddb/
+      size: 2845
+    - name: LFW
+      description: Labeled Faces in the Wild LFW is a public benchmarking dataset created and maintained by researchers at the University of Massachusetts, Amherst.
+      link: http://vis-www.cs.umass.edu/lfw/
+      size: 13232
+  performance_metrics:
+    type: useful type
+    value: '7000'
+    confidence_interval:
+      lower_bound: '6889'
+      upper_bound: '7111'
+    raw: https://modelcards.withgoogle.com/assets/files/Face_Detection_Model-Card-all_chart_data.tsv

--- a/src/validator/index.test.ts
+++ b/src/validator/index.test.ts
@@ -3,7 +3,7 @@ import { join } from 'path';
 import { validator } from '.';
 
 describe('validator', () => {
-  test('modelcard schema', async () => {
+  test('valid model card schema', async () => {
     const content = readFileSync(
       join(__dirname, '__fixtures__/basic.yaml'),
       'utf-8',
@@ -12,5 +12,20 @@ describe('validator', () => {
     const res = await validator(content);
 
     expect(res).toHaveLength(0);
+  });
+
+  test('invalid mode card schema', async () => {
+    const content = readFileSync(
+      join(__dirname, '__fixtures__/invalid_schema.yaml'),
+      'utf-8',
+    );
+
+    const res = await validator(content);
+
+    expect(res).toHaveLength(1);
+
+    expect(res[0].message).toBe(
+      '"performance_metrics" property type must be array',
+    );
   });
 });


### PR DESCRIPTION
Message is now in format `<severity> at <document structure location>: <error message produced by check function>`. HTML support in the check reports is only partial, therefore there are no colors.

Resolves #40 